### PR TITLE
Add support for dialogs in LineLengthProcessor

### DIFF
--- a/core/line.py
+++ b/core/line.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from typing import List
 
 
 class Line(str):
@@ -18,3 +19,7 @@ class Line(str):
 
     def is_dialog(self) -> bool:
         return bool(re.search(r"^(<\/?i>)*[-]", self))
+
+    @staticmethod
+    def merge(lines: List[Line]) -> Line:
+        return Line(" ".join(lines))

--- a/core/section/__init__.py
+++ b/core/section/__init__.py
@@ -32,6 +32,9 @@ class Section:
     def content(self) -> str:
         pass
 
+    def __len__(self) -> int:
+        return len(self.lines)
+
 
 class SrtSection(Section):
     def __init__(self, timing: SrtSectionTiming, lines: List[Line] = []):

--- a/linelength.srt
+++ b/linelength.srt
@@ -17,3 +17,8 @@ pick up the pace.
 00:04:00,000 --> 00:05:00,000
 - What if she's supposed
 to be with me?
+
+5
+00:05:00,000 --> 00:06:00,000
+-I'm gonna call the police,
+this can't keep happening.

--- a/linelength.srt
+++ b/linelength.srt
@@ -10,10 +10,10 @@ What you got?
 
 3
 00:03:00,000 --> 00:04:00,000
-Let me go!
-I mean it!
+All right, let's
+pick up the pace.
 
 4
 00:04:00,000 --> 00:05:00,000
-All right, let's
-pick up the pace.
+- What if she's supposed
+to be with me?

--- a/tests/test_linelengthprocessor.py
+++ b/tests/test_linelengthprocessor.py
@@ -49,6 +49,9 @@ class TestLineLengthProcessor:
         assert processor.split_dialog_chunks(
             [Line("hi"), Line("-bob"), Line("- bye"), Line("bob")]
         ) == [[Line("hi")], [Line("-bob")], [Line("- bye"), Line("bob")]]
+        assert processor.split_dialog_chunks(
+            [Line("-I'm gonna call the police,"), Line("this can't keep happening.")]
+        ) == [[Line("-I'm gonna call the police,"), Line("this can't keep happening.")]]
 
     def test_merge_short_lines(self, processor: LineLengthProcessor):
         sections = processor.subtitle.sections
@@ -62,3 +65,4 @@ class TestLineLengthProcessor:
         section = processor.process_section(sections[3])
         assert len(section.lines) == 1
         assert section.lines[0] == "- What if she's supposed to be with me?"
+        assert processor.process_section(sections[4]) == sections[4]

--- a/tests/test_linelengthprocessor.py
+++ b/tests/test_linelengthprocessor.py
@@ -56,13 +56,13 @@ class TestLineLengthProcessor:
     def test_merge_short_lines(self, processor: LineLengthProcessor):
         sections = processor.subtitle.sections
         section = processor.process_section(sections[0])
-        assert len(section.lines) == 1
+        assert len(section) == 1
         assert section.lines[0] == "Go on now. What you got?"
         assert processor.process_section(sections[1]) == sections[1]
         section = processor.process_section(sections[2])
-        assert len(section.lines) == 1
+        assert len(section) == 1
         assert section.lines[0] == "All right, let's pick up the pace."
         section = processor.process_section(sections[3])
-        assert len(section.lines) == 1
+        assert len(section) == 1
         assert section.lines[0] == "- What if she's supposed to be with me?"
         assert processor.process_section(sections[4]) == sections[4]

--- a/tests/test_linelengthprocessor.py
+++ b/tests/test_linelengthprocessor.py
@@ -16,35 +16,37 @@ class TestLineLengthProcessor:
     def processor(self, subtitle: Subtitle) -> LineLengthProcessor:
         return LineLengthProcessor(subtitle)
 
-    def test_get_slices(self, processor: LineLengthProcessor):
-        assert processor.get_slices([Line("hello"), Line("there")]) == [
+    def test_split_dialog_chunks(self, processor: LineLengthProcessor):
+        assert processor.split_dialog_chunks([Line("hello"), Line("there")]) == [
             [
                 Line("hello"),
                 Line("there"),
             ]
         ]
-        assert processor.get_slices([Line("- hello"), Line("there")]) == [
+        assert processor.split_dialog_chunks([Line("- hello"), Line("there")]) == [
             [
                 Line("- hello"),
                 Line("there"),
             ]
         ]
-        assert processor.get_slices([Line("hello"), Line("- there")]) == [
+        assert processor.split_dialog_chunks([Line("hello"), Line("- there")]) == [
             [Line("hello")],
             [Line("- there")],
         ]
-        assert processor.get_slices([Line("hello"), Line("- there"), Line("man")]) == [
+        assert processor.split_dialog_chunks(
+            [Line("hello"), Line("- there"), Line("man")]
+        ) == [
             [Line("hello")],
             [Line("- there"), Line("man")],
         ]
-        assert processor.get_slices([Line("- hi"), Line("- bye")]) == [
+        assert processor.split_dialog_chunks([Line("- hi"), Line("- bye")]) == [
             [Line("- hi")],
             [Line("- bye")],
         ]
-        assert processor.get_slices(
+        assert processor.split_dialog_chunks(
             [Line("- hi"), Line("bob"), Line("- bye"), Line("bob")]
         ) == [[Line("- hi"), Line("bob")], [Line("- bye"), Line("bob")]]
-        assert processor.get_slices(
+        assert processor.split_dialog_chunks(
             [Line("hi"), Line("-bob"), Line("- bye"), Line("bob")]
         ) == [[Line("hi")], [Line("-bob")], [Line("- bye"), Line("bob")]]
 

--- a/tests/test_linelengthprocessor.py
+++ b/tests/test_linelengthprocessor.py
@@ -1,5 +1,6 @@
 import pytest
 
+from core.line import Line
 from core.parser import SubtitleParser
 from core.subtitle import Subtitle
 from processors.processor import LineLengthProcessor
@@ -15,15 +16,47 @@ class TestLineLengthProcessor:
     def processor(self, subtitle: Subtitle) -> LineLengthProcessor:
         return LineLengthProcessor(subtitle)
 
+    def test_get_slices(self, processor: LineLengthProcessor):
+        assert processor.get_slices([Line("hello"), Line("there")]) == [
+            [
+                Line("hello"),
+                Line("there"),
+            ]
+        ]
+        assert processor.get_slices([Line("- hello"), Line("there")]) == [
+            [
+                Line("- hello"),
+                Line("there"),
+            ]
+        ]
+        assert processor.get_slices([Line("hello"), Line("- there")]) == [
+            [Line("hello")],
+            [Line("- there")],
+        ]
+        assert processor.get_slices([Line("hello"), Line("- there"), Line("man")]) == [
+            [Line("hello")],
+            [Line("- there"), Line("man")],
+        ]
+        assert processor.get_slices([Line("- hi"), Line("- bye")]) == [
+            [Line("- hi")],
+            [Line("- bye")],
+        ]
+        assert processor.get_slices(
+            [Line("- hi"), Line("bob"), Line("- bye"), Line("bob")]
+        ) == [[Line("- hi"), Line("bob")], [Line("- bye"), Line("bob")]]
+        assert processor.get_slices(
+            [Line("hi"), Line("-bob"), Line("- bye"), Line("bob")]
+        ) == [[Line("hi")], [Line("-bob")], [Line("- bye"), Line("bob")]]
+
     def test_merge_short_lines(self, processor: LineLengthProcessor):
-        assert processor.section_meets_criteria(processor.subtitle.sections[0])
-        assert len(processor.subtitle.sections[0].lines) == 2
-        section = processor.process_section(processor.subtitle.sections[0])
+        sections = processor.subtitle.sections
+        section = processor.process_section(sections[0])
         assert len(section.lines) == 1
         assert section.lines[0] == "Go on now. What you got?"
-        assert not processor.section_meets_criteria(processor.subtitle.sections[1])
-        assert processor.section_meets_criteria(processor.subtitle.sections[3])
-        assert len(processor.subtitle.sections[3].lines) == 2
-        section = processor.process_section(processor.subtitle.sections[3])
+        assert processor.process_section(sections[1]) == sections[1]
+        section = processor.process_section(sections[2])
         assert len(section.lines) == 1
         assert section.lines[0] == "All right, let's pick up the pace."
+        section = processor.process_section(sections[3])
+        assert len(section.lines) == 1
+        assert section.lines[0] == "- What if she's supposed to be with me?"


### PR DESCRIPTION
Slice sections in dialog chunks. This allows to operate the LineLengthProcessor context-aware so that it wouldn't just skip dialog sections.